### PR TITLE
Fix DESCRIPTION typo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,8 +3,8 @@ Title: C++ Library for OpenMP-based multi-threaded sequential profiling of
 	Binary Alignment Map (BAM) files
 Version: 1.9.2
 Date: 2024-09-07
-Authors@R: c(person("Alex Chit Hei", "Wong", email="alexchwong.github@gmail.com", 
-		role=c("aut", "cre", "cph")),
+Authors@R: person("Alex Chit Hei", "Wong", email="alexchwong.github@gmail.com", 
+		role=c("aut", "cre", "cph"))
 Description: This packages provides C++ header files for developers wishing to
     create R packages that processes BAM files. ompBAM automates file access,
 	memory management, and handling of multiple threads 'behind the scenes', so


### PR DESCRIPTION
We see 

```
Failed to parse Authors@R for package 'ompBAM': <text>:3:0: unexpected end of input
1: c(person("Alex Chit Hei", "Wong", email="alexchwong.github@gmail.com", 
2:                 role=c("aut", "cre", "cph")),
  ^)
```